### PR TITLE
暂时解决焦点在非TVOS显示

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -167,7 +167,7 @@ export default function HomeScreen() {
       <View style={dynamicStyles.headerContainer}>
         <View style={{ flexDirection: "row", alignItems: "center" }}>
           <ThemedText style={dynamicStyles.headerTitle}>首页</ThemedText>
-          <Pressable android_ripple={Platform.isTV ? {color:'transparent'} : ( deviceType==='tv' ? {color: Colors.dark.link}: {color:'transparent'})} style={{ marginLeft: 20 }} onPress={() => router.push("/live")}>
+          <Pressable android_ripple={Platform.isTV || deviceType !== 'tv'? { color: 'transparent' } : { color: Colors.dark.link }} style={{ marginLeft: 20 }} onPress={() => router.push("/live")}>
             {({ focused }) => (
               <ThemedText style={[dynamicStyles.headerTitle, { color: focused ? "white" : "grey" }]}>直播</ThemedText>
             )}

--- a/components/StyledButton.tsx
+++ b/components/StyledButton.tsx
@@ -110,7 +110,7 @@ export const StyledButton = forwardRef<View, StyledButtonProps>(
     return (
       <Animated.View style={[animationStyle, style]}>
         <Pressable
-          android_ripple={Platform.isTV ? { color: 'transparent' } : (deviceType === 'tv' ? { color: Colors.dark.link } : { color: 'transparent' })}
+          android_ripple={Platform.isTV || deviceType !== 'tv'? { color: 'transparent' } : { color: Colors.dark.link }}
           ref={ref}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}

--- a/components/VideoCard.tv.tsx
+++ b/components/VideoCard.tv.tsx
@@ -151,7 +151,7 @@ const VideoCard = forwardRef<View, VideoCardProps>(
     return (
       <Animated.View style={[styles.wrapper, animatedStyle, { opacity: fadeAnim }]}>
         <Pressable
-          android_ripple={Platform.isTV ? { color: 'transparent' } : (deviceType === 'tv' ? { color: Colors.dark.link } : { color: 'transparent' })}
+          android_ripple={Platform.isTV || deviceType !== 'tv'? { color: 'transparent' } : { color: Colors.dark.link }}
           onPress={handlePress}
           onLongPress={handleLongPress}
           onFocus={handleFocus}


### PR DESCRIPTION
利用`Pressable`组件的`android_ripple`属性可以设置颜色，但是参数比较少，没有圆角边框什么的，不过可以辨别焦点位置
```
<Pressable 
    android_ripple={Platform.isTV || deviceType !== 'tv'? { color: 'transparent' } : { color: Colors.dark.link }}
    ......
>
```
我改了`StyledButton`, `VideoCard.tv`和`index.tsx`中的上述属性，效果还凑合。

遗留问题是设置中的输入框用遥控器还无法聚焦，临时解决办法是接个鼠标上去点点

![cced3cb96069618508d31c96480e1907](https://github.com/user-attachments/assets/c585c976-0874-4be2-a38d-84f1ac3d9053)

![87ab39497ebe039124525ce9d3bbcfb9](https://github.com/user-attachments/assets/acfa6dc1-e48c-4667-a0aa-c18a45be9698)
